### PR TITLE
Add cronjob support instead of using custom scheduler 

### DIFF
--- a/k8s/create_cronjob.go
+++ b/k8s/create_cronjob.go
@@ -1,0 +1,67 @@
+package k8s
+
+import (
+	"github.com/ahmagdy/k8s-pod-scheduler/job"
+	"go.uber.org/zap"
+	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/api/batch/v1beta1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/securitycontext"
+)
+
+func (k8s *k8SClient) CreateCronJob(job *job.SchedulerJob, namespace string) (string, error) {
+	if namespace == "" {
+		namespace = k8s.GetCurrentNamespace()
+	}
+	k8s.log.Info("Creating cronjob",
+		zap.String("cronjob_name", job.Name),
+		zap.String("namespace", namespace),
+	)
+	objectMeta := metav1.ObjectMeta{
+		GenerateName: job.Name,
+		Labels: map[string]string{
+			"name": job.Name,
+			"type": "production",
+		},
+	}
+	ttlTime := int32(0)
+	jobSpec := batchv1.JobSpec{
+		TTLSecondsAfterFinished: &ttlTime,
+		Template: v1.PodTemplateSpec{
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name:                   job.Name,
+						Image:                  job.Image,
+						TerminationMessagePath: v1.TerminationMessagePathDefault,
+						ImagePullPolicy:        v1.PullIfNotPresent,
+						SecurityContext:        securitycontext.ValidSecurityContextWithContainerDefaults(),
+						Command:                job.Commands,
+						Args:                   job.Args,
+					},
+				},
+				RestartPolicy: v1.RestartPolicyOnFailure,
+				DNSPolicy:     v1.DNSDefault,
+			},
+		},
+	}
+
+	cronObj, err := k8s.clientset.BatchV1beta1().CronJobs(namespace).Create(&v1beta1.CronJob{
+		ObjectMeta: objectMeta,
+		Spec: v1beta1.CronJobSpec{
+			Schedule:          job.Cron,
+			ConcurrencyPolicy: v1beta1.ForbidConcurrent,
+			JobTemplate: v1beta1.JobTemplateSpec{
+				Spec: jobSpec,
+			},
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+	k8s.log.Info(cronObj.GetName())
+
+	return cronObj.GetName(), nil
+
+}

--- a/k8s/create_cronjob_test.go
+++ b/k8s/create_cronjob_test.go
@@ -1,0 +1,59 @@
+package k8s
+
+import (
+	"testing"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/ahmagdy/k8s-pod-scheduler/job"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateCronJob(t *testing.T) {
+	type input struct {
+		namespace string
+		job       *job.SchedulerJob
+	}
+	tests := []struct {
+		name              string
+		input             input
+		expectedError     error
+		expectedNamespace string
+	}{
+		{
+			name: "cronjob is created with provided namespace",
+			input: input{
+				namespace: "abcd",
+				job: &job.SchedulerJob{
+					Name: "my-job",
+				},
+			},
+			expectedNamespace: "abcd",
+		},
+		{
+			name: "cron is created with default namespace if not provided",
+			input: input{
+				job: &job.SchedulerJob{
+					Name: "my-job",
+				},
+			},
+			expectedNamespace: "default",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			k8sClient := newTestSimpleK8s(t)
+			_, err := k8sClient.CreateCronJob(tc.input.job, tc.input.namespace)
+
+			require.Equal(t, tc.expectedError, err)
+			crons, err := k8sClient.(*k8SClient).clientset.BatchV1beta1().CronJobs("").List(v1.ListOptions{})
+			require.Equal(t, tc.expectedNamespace, crons.Items[0].Namespace)
+
+			// It should be the returned name from k8sClient.CreatePod but k8s fake client implementation doesn't evaluate the pod
+			// require.Contains(t, name, tc.input.job.Name)
+			require.Contains(t, crons.Items[0].GetGenerateName(), tc.input.job.Name)
+		})
+	}
+}

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -18,6 +18,7 @@ import (
 type K8S interface {
 	GetPod(name string, namespace string) (*v1.Pod, error)
 	GetCurrentNamespace() string
+	CreateCronJob(job *job.SchedulerJob, namespace string) (string, error)
 	CreatePod(job *job.SchedulerJob, namespace string) (string, error)
 	CreateNamespace(name string) error
 	DeletePod(name string, namespace string) error


### PR DESCRIPTION
One of the limitations in cronjob resource that `TTLSecondsAfterFinished` to remove the pod after finishing the pod is in Alpha and need to be changed on the server.
This is an extra step for the user and it's not stable.